### PR TITLE
refactor: unify auth guard verification flow

### DIFF
--- a/components/auth-guard.tsx
+++ b/components/auth-guard.tsx
@@ -15,93 +15,161 @@ import SiteHeader from '@/components/common/site-header/site-header';
 import PageBackground from '@/components/common/page-background/page-background';
 import PageContainer from '@/components/common/page-container/page-container';
 
+const AUTH_SUCCESS_REDIRECT_DELAY_MS = 1500;
+
 interface AuthGuardProps {
   children: React.ReactNode;
   requiredPage: 'complete' | 'survey';
   showHeader?: boolean;
 }
 
+interface AuthFormProps {
+  phoneNumber: string;
+  error: string;
+  isPending: boolean;
+  onPhoneChange: (value: string) => void;
+  onSubmit: () => void;
+  onPhoneKeyDown: (e: React.KeyboardEvent) => void;
+}
+
+function AuthSuccessMessage() {
+  return (
+    <div className='text-center'>
+      <div className='inline-flex items-center justify-center w-16 h-16 bg-green-500 rounded-full mb-6'>
+        <CheckCircle className='h-8 w-8 text-white' />
+      </div>
+      <h3 className='text-xl font-bold text-green-600 mb-2'>인증 완료!</h3>
+      <p className='text-gray-600'>잠시 후 페이지로 이동합니다...</p>
+    </div>
+  );
+}
+
+function AuthPhoneVerificationForm({
+  phoneNumber,
+  error,
+  isPending,
+  onPhoneChange,
+  onSubmit,
+  onPhoneKeyDown,
+}: AuthFormProps) {
+  return (
+    <div className='space-y-6'>
+      <div>
+        <Label htmlFor='phone' className='text-gray-700 font-medium'>
+          결제 시 입력한 전화번호를 입력해주세요
+        </Label>
+        <Input
+          id='phone'
+          type='tel'
+          value={phoneNumber}
+          onChange={(e) => onPhoneChange(e.target.value)}
+          onKeyDown={onPhoneKeyDown}
+          placeholder='010-1234-5678'
+          className='mt-2 text-lg'
+          disabled={isPending}
+        />
+      </div>
+
+      {error && (
+        <div className='flex items-center space-x-2 p-3 bg-red-50 border border-red-200 rounded-lg'>
+          <AlertCircle className='h-5 w-5 text-red-500' />
+          <span className='text-red-600 text-sm'>{error}</span>
+        </div>
+      )}
+
+      <Button
+        onClick={onSubmit}
+        disabled={isPending || !phoneNumber.trim()}
+        className='w-full bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white py-3 text-lg font-semibold rounded-lg shadow-lg hover:shadow-xl transition-all duration-300'
+      >
+        {isPending ? (
+          <div className='flex items-center'>
+            <div className='animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2'></div>
+            인증 중...
+          </div>
+        ) : (
+          '인증하기'
+        )}
+      </Button>
+
+      <div className='text-center'>
+        <p className='text-sm text-gray-500 mb-4'>아직 결제를 완료하지 않으셨나요?</p>
+        <Link href='/apply'>
+          <Button
+            variant='outline'
+            className='border-2 border-pink-400 text-pink-600 hover:bg-pink-50 bg-transparent'
+          >
+            결제하러 가기
+          </Button>
+        </Link>
+      </div>
+
+      <div className='bg-blue-50 border border-blue-200 rounded-lg p-4'>
+        <h4 className='font-semibold text-blue-800 mb-2'>💡 도움말</h4>
+        <ul className='text-sm text-blue-700 space-y-1'>
+          <li>• 결제 시 입력한 전화번호와 정확히 일치해야 합니다</li>
+          <li>• 인증은 24시간 동안 유효합니다</li>
+          <li>• 문제가 있으시면 고객센터로 문의해주세요</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+
 export default function AuthGuard({ children, requiredPage, showHeader = true }: AuthGuardProps) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [phoneNumber, setPhoneNumber] = useState('');
-  const [isVerifying, setIsVerifying] = useState(false);
   const [error, setError] = useState('');
   const [showSuccess, setShowSuccess] = useState(false);
-  const { mutate, isPending } = useMutation({
-    mutationFn: () => valueExists('apply', phoneNumber.replace('-', '')),
-    onSuccess: () => {
-      setIsVerifying(false);
-      setShowSuccess(true);
-      setTimeout(() => {
-        setIsAuthenticated(true);
-      }, 1500);
-    },
-    onError: (error) => {
-      console.error(error);
-    },
+
+  const { mutateAsync: verifyPhoneNumber, isPending } = useMutation({
+    mutationFn: (normalizedPhone: string) => valueExists('apply', normalizedPhone),
   });
 
   const handlePhoneVerification = async () => {
-    setIsVerifying(true);
     setError('');
+    const normalizedPhoneNumber = phoneNumber.replace(/[^0-9]/g, '');
+
+    if (!normalizedPhoneNumber) {
+      setError('전화번호를 입력해주세요.');
+      return;
+    }
 
     try {
-      const userInfo = localStorage.getItem('userInfo');
-      const result = await valueExists('apply', phoneNumber.replaceAll('-', ''));
+      const doesPaymentInfoExist = await verifyPhoneNumber(normalizedPhoneNumber);
 
-      if (!userInfo) {
-        if (!result) {
-          setError('결제 정보를 찾을 수 없습니다. 먼저 결제를 완료해주세요.');
-          setIsVerifying(false);
-          return;
-        }
+      if (!doesPaymentInfoExist) {
+        setError('결제 정보를 찾을 수 없습니다. 먼저 결제를 완료해주세요.');
         return;
       }
 
-      const user = JSON.parse(userInfo);
-      const normalizedInput = phoneNumber.replace(/[^0-9]/g, '');
+      const authToken = {
+        phone: normalizedPhoneNumber,
+        timestamp: new Date().toISOString(),
+        verified: true,
+      };
 
-      await new Promise((resolve) => setTimeout(resolve, 1500));
+      localStorage.setItem('authToken', JSON.stringify(authToken));
+      setShowSuccess(true);
 
-      if (normalizedInput) {
-        const authToken = {
-          phone: user.phone,
-          timestamp: new Date().toISOString(),
-          verified: true,
-        };
-
-        localStorage.setItem('authToken', JSON.stringify(authToken));
-
-        setShowSuccess(true);
-        setTimeout(() => {
-          setIsAuthenticated(true);
-        }, 1500);
-      } else {
-        setError('결제 시 입력한 전화번호와 일치하지 않습니다.');
-      }
+      window.setTimeout(() => {
+        setIsAuthenticated(true);
+      }, AUTH_SUCCESS_REDIRECT_DELAY_MS);
     } catch {
       setError('인증 중 오류가 발생했습니다. 다시 시도해주세요.');
-    } finally {
-      setIsVerifying(false);
     }
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
-      handlePhoneVerification();
+      void handlePhoneVerification();
     }
   };
 
-  if (isPending) {
-    return (
-      <PageBackground className='bg-gradient-to-br from-pink-50 via-purple-50 to-indigo-50 flex items-center justify-center'>
-        <div className='text-center'>
-          <div className='w-16 h-16 border-4 border-pink-200 border-t-pink-500 rounded-full animate-spin mx-auto mb-4'></div>
-          <p className='text-gray-600'>인증 확인 중...</p>
-        </div>
-      </PageBackground>
-    );
-  }
+  const handlePhoneNumberChange = (value: string) => {
+    setPhoneNumber(value);
+    setError('');
+  };
 
   if (!isAuthenticated) {
     return (
@@ -138,77 +206,16 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
               </CardHeader>
               <CardContent className='p-8'>
                 {showSuccess ? (
-                  <div className='text-center'>
-                    <div className='inline-flex items-center justify-center w-16 h-16 bg-green-500 rounded-full mb-6'>
-                      <CheckCircle className='h-8 w-8 text-white' />
-                    </div>
-                    <h3 className='text-xl font-bold text-green-600 mb-2'>인증 완료!</h3>
-                    <p className='text-gray-600'>잠시 후 페이지로 이동합니다...</p>
-                  </div>
+                  <AuthSuccessMessage />
                 ) : (
-                  <div className='space-y-6'>
-                    <div>
-                      <Label htmlFor='phone' className='text-gray-700 font-medium'>
-                        결제 시 입력한 전화번호를 입력해주세요
-                      </Label>
-                      <Input
-                        id='phone'
-                        type='tel'
-                        value={phoneNumber}
-                        onChange={(e) => {
-                          setPhoneNumber(e.target.value);
-                          setError('');
-                        }}
-                        onKeyPress={handleKeyPress}
-                        placeholder='010-1234-5678'
-                        className='mt-2 text-lg'
-                        disabled={isVerifying}
-                      />
-                    </div>
-
-                    {error && (
-                      <div className='flex items-center space-x-2 p-3 bg-red-50 border border-red-200 rounded-lg'>
-                        <AlertCircle className='h-5 w-5 text-red-500' />
-                        <span className='text-red-600 text-sm'>{error}</span>
-                      </div>
-                    )}
-
-                    <Button
-                      onClick={() => mutate()}
-                      disabled={isVerifying || !phoneNumber.trim()}
-                      className='w-full bg-gradient-to-r from-pink-500 to-purple-600 hover:from-pink-600 hover:to-purple-700 text-white py-3 text-lg font-semibold rounded-lg shadow-lg hover:shadow-xl transition-all duration-300'
-                    >
-                      {isVerifying ? (
-                        <div className='flex items-center'>
-                          <div className='animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2'></div>
-                          인증 중...
-                        </div>
-                      ) : (
-                        '인증하기'
-                      )}
-                    </Button>
-
-                    <div className='text-center'>
-                      <p className='text-sm text-gray-500 mb-4'>아직 결제를 완료하지 않으셨나요?</p>
-                      <Link href='/apply'>
-                        <Button
-                          variant='outline'
-                          className='border-2 border-pink-400 text-pink-600 hover:bg-pink-50 bg-transparent'
-                        >
-                          결제하러 가기
-                        </Button>
-                      </Link>
-                    </div>
-
-                    <div className='bg-blue-50 border border-blue-200 rounded-lg p-4'>
-                      <h4 className='font-semibold text-blue-800 mb-2'>💡 도움말</h4>
-                      <ul className='text-sm text-blue-700 space-y-1'>
-                        <li>• 결제 시 입력한 전화번호와 정확히 일치해야 합니다</li>
-                        <li>• 인증은 24시간 동안 유효합니다</li>
-                        <li>• 문제가 있으시면 고객센터로 문의해주세요</li>
-                      </ul>
-                    </div>
-                  </div>
+                  <AuthPhoneVerificationForm
+                    phoneNumber={phoneNumber}
+                    error={error}
+                    isPending={isPending}
+                    onPhoneChange={handlePhoneNumberChange}
+                    onSubmit={() => void handlePhoneVerification()}
+                    onPhoneKeyDown={handleKeyDown}
+                  />
                 )}
               </CardContent>
             </Card>


### PR DESCRIPTION
## Summary

  AuthGuard의 인증 진입/검증/성공 처리 흐름을 단일 경로로 통합했습니다.
  기존에 분리되어 있던 useMutation 경로와 handlePhoneVerification 경로를 하나로 정리해, 버튼 클릭 시 동일한 검증/상태
  전이가 일어나도록 맞췄습니다.

  ## Related Issues

  - close #19

  ## Changes

  - components/auth-guard.tsx 인증 로직 단일화
  - 인증 버튼 및 Enter 입력 모두 단일 핸들러(handlePhoneVerification)만 실행하도록 변경
  - 성공/실패/로딩 상태 전이 일관화
      - 성공: authToken 저장 → 성공 UI → 인증 상태 반영
      - 실패: 단일 에러 메시지 경로
      - 로딩: isPending 기준으로 UI/버튼 비활성화 통일
  - return 내부 복잡도 완화를 위해 인증 성공/입력 폼 UI를 하위 컴포넌트로 분리

  ## How To Test

  1. pnpm install
  2. pnpm dev
  3. 브라우저에서 인증이 필요한 페이지(/complete 또는 /survey) 진입
  4. 유효하지 않은 전화번호 입력 후 인증:
      - 결제 정보 없음 에러가 표시되는지 확인
  5. 유효한 전화번호 입력 후 인증:
      - 로딩 상태 표시
      - 성공 UI 표시 후 페이지 접근 허용되는지 확인
      - localStorage.authToken이 저장되는지 확인
  6. 입력창에서 Enter 키로도 동일하게 인증 동작하는지 확인

  ## Checklist

  - [x] Title follows the convention (e.g., feat: add global audio seek guard)
  - [ ] Build passes locally (pnpm build)
  - [x] No breaking changes, or they are documented below
  - [ ] Tests added/updated where appropriate
  - [x] Docs/comments updated where helpful

  ## Breaking Changes (if any)

  없음.

  ## Notes For Reviewers

 없음.

  ## Screenshots / Recordings (if UI changes)

  UI 디자인 변경 없음.