### PR TITLE
refactor: useSurveyChat 이펙트/콜백 의존성 안정화

### DIFF
--- a/app/survey/hooks/useSurveyChat.ts
+++ b/app/survey/hooks/useSurveyChat.ts
@@ -18,6 +18,8 @@ export function useSurveyChat() {
   const chatEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const lastHandledResponseRef = useRef<ChatResponse | null>(null);
+  const currentQuestionRef = useRef(currentQuestion);
+  const answersRef = useRef(answers);
   const { completeSurvey } = useSurveyCompletion();
 
   const initialMessage = `안녕하세요! 당신만의 완벽한 스타일을 찾아드릴게요 ✨\n\n총 ${totalQuestions}개의 질문을 통해 당신의 골격 타입을 정확히 분석해드릴게요.\n\n옵션을 선택하거나 자유롭게 대화하듯 답변해주세요.\n\n첫 번째 질문입니다:\n${surveyQuestions[0].question}\n- ${surveyQuestions[0].options[0].label}\n- ${surveyQuestions[0].options[1].label}\n- ${surveyQuestions[0].options[2].label}\n`;
@@ -34,6 +36,14 @@ export function useSurveyChat() {
     chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages]);
 
+  useEffect(() => {
+    currentQuestionRef.current = currentQuestion;
+  }, [currentQuestion]);
+
+  useEffect(() => {
+    answersRef.current = answers;
+  }, [answers]);
+
   const handleChatResponse = useCallback(
     async (response: ChatResponse) => {
       setIsProcessing(true);
@@ -47,13 +57,15 @@ export function useSurveyChat() {
       }
 
       setLastResponseStatus('success');
-      const newAnswers = [...answers, response.selected];
+      const newAnswers = [...answersRef.current, response.selected];
+      answersRef.current = newAnswers;
       setAnswers(newAnswers);
 
-      if (currentQuestion < totalQuestions - 1) {
-        const nextIndex = currentQuestion + 1;
+      if (currentQuestionRef.current < totalQuestions - 1) {
+        const nextIndex = currentQuestionRef.current + 1;
 
         window.setTimeout(() => {
+          currentQuestionRef.current = nextIndex;
           setCurrentQuestion(nextIndex);
 
           const questionText = response.nextQuestion || surveyQuestions[nextIndex].question;
@@ -72,7 +84,7 @@ export function useSurveyChat() {
         setIsProcessing(false);
       }
     },
-    [addBotMessage, answers, completeSurvey, currentQuestion, totalQuestions],
+    [addBotMessage, completeSurvey, totalQuestions],
   );
 
   useEffect(() => {


### PR DESCRIPTION
 ## Summary

  useSurveyChat 내부의 콜백/이펙트 의존성을 정리해 react-hooks/exhaustive-deps 경고를 제거하고, 동작 예측 가능성을 높
  였습니다.
  핵심은 handleChatResponse를 안정적으로 유지하고, 최신 상태 참조는 ref로 분리해 불필요한 재생성/재실행 가능성을 줄인
  것입니다.

  ## Related Issues

  - close #22

  ## Changes

  - handleChatResponse의 의존성을 단순화하고 안정적인 useCallback으로 유지
  - currentQuestion, answers를 ref로 동기화해 콜백 내부에서 최신 상태 참조
  - useEffect dependency 배열을 실제 트리거 기준으로 정리
  - useSurveyChat.ts의 react-hooks/exhaustive-deps 경고 제거

  ## How To Test

  1. pnpm lint 실행
  2. 설문 페이지 진입 후 답변 진행
  3. 질문 전환, 응답 실패 처리, 마지막 질문 완료 동작이 기존과 동일한지 확인

  ## Checklist

  - [x] Title follows the convention (e.g., feat: add global audio seek guard)
  - [ ] Build passes locally (pnpm build)
  - [x] No breaking changes, or they are documented below
  - [ ] Tests added/updated where appropriate
  - [x] Docs/comments updated where helpful

  ## Breaking Changes (if any)

  없음

  ## Notes For Reviewers

  - 챗 API 인터페이스 변경은 없습니다.
  - 상태 처리 방식만 정리한 리팩터링이며, 의도된 런타임 동작은 유지됩니다.

  ## Screenshots / Recordings (if UI changes)

  UI 변경 없음.