### PR TITLE
refactor: client 스토리지 접근 중앙화

### DIFF
--- a/app/apply/components/application-form/useApplicationSubmit.ts
+++ b/app/apply/components/application-form/useApplicationSubmit.ts
@@ -4,6 +4,7 @@ import { applyBodyDiagnosis } from '@/firebase';
 import { useApplyUserInfoStore } from '@/hooks/useApplyUserInfoStore';
 import { BodyDiagnosisFormData } from '@/types/body';
 import { SUBMIT_DELAY_MS } from '@/app/apply/components/application-form/application-form.constants';
+import { setStorageJson, STORAGE_KEYS } from '@/lib/client-storage';
 
 type UseApplicationSubmitParams = {
   formData: BodyDiagnosisFormData;
@@ -39,7 +40,7 @@ export function useApplicationSubmit({ formData, isFormValid }: UseApplicationSu
     try {
       await applyBodyDiagnosis(formData);
       await wait(SUBMIT_DELAY_MS);
-      localStorage.setItem('userInfo', JSON.stringify(formData));
+      setStorageJson(STORAGE_KEYS.USER_INFO, formData);
       router.push('/complete');
     } catch {
       setSubmitError('신청 처리 중 오류가 발생했어요. 잠시 후 다시 시도해주세요.');

--- a/app/complete/_section/OrderSummaryClient.tsx
+++ b/app/complete/_section/OrderSummaryClient.tsx
@@ -3,16 +3,15 @@
 import { useEffect, useState } from 'react';
 import type { BodyDiagnosisFormData } from '@/types/body';
 import OrderSummary from '@/app/complete/_section/OrderSummary';
+import { getStorageJson, STORAGE_KEYS } from '@/lib/client-storage';
 
 export default function OrderSummaryClient() {
   const [userInfo, setUserInfo] = useState<BodyDiagnosisFormData>();
   const [paymentDateLabel, setPaymentDateLabel] = useState('');
 
   useEffect(() => {
-    const info = localStorage.getItem('userInfo');
-    if (info) {
-      setUserInfo(JSON.parse(info));
-    }
+    const info = getStorageJson<BodyDiagnosisFormData>(STORAGE_KEYS.USER_INFO);
+    if (info) setUserInfo(info);
     setPaymentDateLabel(new Date().toLocaleString('ko-KR'));
   }, []);
 

--- a/app/result/components/result-client/ResultClient.tsx
+++ b/app/result/components/result-client/ResultClient.tsx
@@ -12,6 +12,7 @@ import ResultContent from '@/app/result/_section/ResultContent';
 import PdfGuideSection from '@/app/result/_section/PdfGuideSection';
 import PageContainer from '@/components/common/page-container/page-container';
 import { useResultPdfGenerator } from '@/app/result/components/result-client/hooks/useResultPdfGenerator';
+import { getStorageJson, STORAGE_KEYS } from '@/lib/client-storage';
 
 export default function ResultClient() {
   const resultRef = useRef<HTMLDivElement>(null);
@@ -32,14 +33,10 @@ export default function ResultClient() {
   }, []);
 
   const handleRetry = async () => {
-    let answers: string[] = [];
-    try {
-      const rawAnswers = localStorage.getItem('surveyAnswers');
-      const parsedAnswers = rawAnswers ? JSON.parse(rawAnswers) : [];
-      answers = Array.isArray(parsedAnswers) ? parsedAnswers : [];
-    } catch {
-      answers = [];
-    }
+    const savedAnswers = getStorageJson<unknown>(STORAGE_KEYS.SURVEY_ANSWERS);
+    const answers = Array.isArray(savedAnswers)
+      ? savedAnswers.filter((answer) => typeof answer === 'string')
+      : [];
 
     if (!answers.length || !gender || height <= 0 || weight <= 0) {
       alert('재요청에 필요한 설문 정보가 없습니다. 설문을 다시 진행해주세요.');

--- a/app/survey/hooks/useSurveyCompletion.ts
+++ b/app/survey/hooks/useSurveyCompletion.ts
@@ -5,19 +5,11 @@ import { useMutation } from '@tanstack/react-query';
 import { saveSurveyAnswers } from '@/firebase';
 import { useApplyUserInfoStore } from '@/hooks/useApplyUserInfoStore';
 import { useBodyResultStore } from '@/hooks/useBodyResultStore';
-
-const AUTH_TOKEN_STORAGE_KEY = 'authToken';
+import { getStorageJson, setStorageJson, STORAGE_KEYS } from '@/lib/client-storage';
 
 function getPhoneFromAuthToken(): string | null {
-  try {
-    const authTokenRaw = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
-    if (!authTokenRaw) return null;
-
-    const token = JSON.parse(authTokenRaw) as { phone?: string };
-    return token.phone ?? null;
-  } catch {
-    return null;
-  }
+  const token = getStorageJson<{ phone?: string }>(STORAGE_KEYS.AUTH_TOKEN);
+  return token?.phone ?? null;
 }
 
 interface CompleteSurveyParams {
@@ -45,7 +37,7 @@ export function useSurveyCompletion() {
         }
       }
 
-      localStorage.setItem('surveyAnswers', JSON.stringify(answers));
+      setStorageJson(STORAGE_KEYS.SURVEY_ANSWERS, answers);
 
       clearBodyResult();
       setStatus('loading');

--- a/components/auth-guard.tsx
+++ b/components/auth-guard.tsx
@@ -14,6 +14,7 @@ import { useMutation } from '@tanstack/react-query';
 import SiteHeader from '@/components/common/site-header/site-header';
 import PageBackground from '@/components/common/page-background/page-background';
 import PageContainer from '@/components/common/page-container/page-container';
+import { setStorageJson, STORAGE_KEYS } from '@/lib/client-storage';
 
 const AUTH_SUCCESS_REDIRECT_DELAY_MS = 1500;
 
@@ -149,7 +150,7 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
         verified: true,
       };
 
-      localStorage.setItem('authToken', JSON.stringify(authToken));
+      setStorageJson(STORAGE_KEYS.AUTH_TOKEN, authToken);
       setShowSuccess(true);
 
       window.setTimeout(() => {

--- a/lib/client-storage.ts
+++ b/lib/client-storage.ts
@@ -1,0 +1,60 @@
+const isBrowser = () => typeof window !== 'undefined';
+
+export const STORAGE_KEYS = {
+  AUTH_TOKEN: 'authToken',
+  USER_INFO: 'userInfo',
+  SURVEY_ANSWERS: 'surveyAnswers',
+} as const;
+
+type StorageKey = (typeof STORAGE_KEYS)[keyof typeof STORAGE_KEYS];
+
+export function getStorageItem(key: StorageKey): string | null {
+  if (!isBrowser()) return null;
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+export function setStorageItem(key: StorageKey, value: string): boolean {
+  if (!isBrowser()) return false;
+
+  try {
+    window.localStorage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function removeStorageItem(key: StorageKey): boolean {
+  if (!isBrowser()) return false;
+
+  try {
+    window.localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function getStorageJson<T>(key: StorageKey): T | null {
+  const rawValue = getStorageItem(key);
+  if (!rawValue) return null;
+
+  try {
+    return JSON.parse(rawValue) as T;
+  } catch {
+    return null;
+  }
+}
+
+export function setStorageJson<T>(key: StorageKey, value: T): boolean {
+  try {
+    return setStorageItem(key, JSON.stringify(value));
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

  localStorage 직접 접근을 공통 유틸로 계층화해 키/파싱/예외 처리 패턴을 일관되게 정리했습니다.
  #25 이슈의 목표대로 저장소 키 상수화와 주요 호출부 치환을 완료했습니다.

  ## Related Issues

  - close #25

  ## Changes

  - lib/client-storage.ts 추가
  - 스토리지 키 상수 추가: AUTH_TOKEN, USER_INFO, SURVEY_ANSWERS
  - 공통 헬퍼 추가:
      - getStorageItem, setStorageItem, removeStorageItem
      - getStorageJson, setStorageJson
  - 직접 localStorage 접근 치환:
      - components/auth-guard.tsx
      - app/apply/components/application-form/useApplicationSubmit.ts
      - app/survey/hooks/useSurveyCompletion.ts
      - app/complete/_section/OrderSummaryClient.tsx
      - app/result/components/result-client/ResultClient.tsx
  - ResultClient에서 저장된 설문 응답 재사용 시 문자열 배열만 허용하도록 타입 방어 추가

  ## How To Test

  1. pnpm lint 실행
  2. /apply에서 신청 후 /complete 이동 시 요약 정보 정상 표시 확인
  3. /survey 완료 후 /result 이동 및 재시도 버튼 동작 확인
  4. /complete, /survey 접근 시 인증 흐름(전화번호 입력) 정상 동작 확인

  ## Checklist

  - [x] Title follows the convention (e.g., feat: add global audio seek guard)
  - [ ] Build passes locally (pnpm build)
  - [x] No breaking changes, or they are documented below
  - [ ] Tests added/updated where appropriate
  - [x] Docs/comments updated where helpful

  ## Breaking Changes (if any)

  없음.

  ## Notes For Reviewers
없음.

  ## Screenshots / Recordings (if UI changes)

  UI 변경 없음.