### PR TITLE
chore: Turbopack root 경고 해결을 위해 프로젝트 루트 명시

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,14 @@
 import type { NextConfig } from 'next';
 import { withSentryConfig } from '@sentry/nextjs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const configDir = path.dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  turbopack: {
+    root: configDir,
+  },
 };
 
 export default withSentryConfig(nextConfig, {


### PR DESCRIPTION
 ## Summary

  next.config.ts에 turbopack.root를 명시해 Turbopack이 프로젝트 루트를 명확히 인식하도록 수정했습니다.
  상위 디렉토리의 lockfile 감지로 발생하던 workspace root 경고를 제거하는 것이 목적입니다.

  ## Related Issues

  - close #28

  ## Changes

  - next.config.ts
  - node:path, node:url을 사용해 설정 파일 기준 절대 경로 계산
  - nextConfig.turbopack.root에 프로젝트 루트 경로 지정

  ## How To Test

  1. 프로젝트 루트에서 pnpm build 실행
  2. 빌드 로그에서 Turbopack의 workspace root 관련 경고가 출력되지 않는지 확인

  ## Checklist

  - [x] Title follows the convention (e.g., feat: add global audio seek guard)
  - [ ] Build passes locally (pnpm build)
  - [x] No breaking changes, or they are documented below
  - [ ] Tests added/updated where appropriate
  - [x] Docs/comments updated where helpful

  ## Breaking Changes (if any)

  없음.

  ## Notes For Reviewers

  현재 환경에서는 외부 네트워크 제한으로 Google Fonts(Inter) fetch 실패가 발생할 수 있습니다.
  이번 PR의 범위는 Turbopack root 경고 제거이며, 폰트 네트워크 오류는 별도 이슈입니다.

  ## Screenshots / Recordings (if UI changes)

  해당 없음 (UI 변경 없음).