### PR TITLE
Feat: #47 개인정보처리방침 개선

### DIFF
--- a/app/(home)/components/footer/Footer.tsx
+++ b/app/(home)/components/footer/Footer.tsx
@@ -1,4 +1,5 @@
-import { Heart, Mail, Phone } from 'lucide-react';
+﻿import Link from 'next/link';
+import { Heart, Mail } from 'lucide-react';
 
 export default function Footer() {
   return (
@@ -16,10 +17,10 @@ export default function Footer() {
               </div>
             </div>
             <p className='text-gray-400 mb-6 leading-relaxed'>
-              AI 기반 개인 맞춤 스타일링으로 당신만의 완벽한 스타일을 찾아보세요. 전문
-              스타일리스트가 설계한 정확한 진단과 맞춤형 가이드를 제공합니다.
+              AI 기반 개인 맞춤 스타일링 서비스로 당신에게 맞는 진단과 가이드를 제공합니다.
             </p>
           </div>
+
           <div>
             <h3 className='text-xl font-bold mb-6 text-rose-400'>서비스</h3>
             <ul className='space-y-3 text-gray-400'>
@@ -30,12 +31,7 @@ export default function Footer() {
               </li>
               <li>
                 <a href='#service' className='hover:text-rose-400 transition-colors'>
-                  스타일링 가이드
-                </a>
-              </li>
-              <li>
-                <a href='#service' className='hover:text-rose-400 transition-colors'>
-                  컬러 분석
+                  스타일 가이드
                 </a>
               </li>
               <li>
@@ -45,16 +41,13 @@ export default function Footer() {
               </li>
             </ul>
           </div>
+
           <div>
             <h3 className='text-xl font-bold mb-6 text-rose-400'>문의</h3>
             <div className='space-y-3 text-gray-400'>
               <div className='flex items-center'>
                 <Mail className='h-5 w-5 mr-3' />
-                <span>urmode@naver.com</span>
-              </div>
-              <div className='flex items-center'>
-                <Phone className='h-5 w-5 mr-3' />
-                <span>010-6415-1548</span>
+                <span>yourmode0604@gmail.com</span>
               </div>
               <div className='text-sm'>
                 <p>평일 09:00 - 18:00</p>
@@ -63,8 +56,23 @@ export default function Footer() {
             </div>
           </div>
         </div>
-        <div className='border-t border-gray-800 mt-12 pt-8 text-center text-gray-400'>
+
+        <div className='border-t border-gray-800 mt-12 pt-8 text-center text-gray-400 space-y-2'>
           <p>&copy; 2025 Style Me. All rights reserved.</p>
+          <div className='flex items-center justify-center gap-4 text-sm'>
+            <Link
+              href='/privacy'
+              className='hover:text-rose-400 transition-colors underline-offset-2 hover:underline'
+            >
+              개인정보처리방침
+            </Link>
+            <Link
+              href='/terms'
+              className='hover:text-rose-400 transition-colors underline-offset-2 hover:underline'
+            >
+              이용약관
+            </Link>
+          </div>
         </div>
       </div>
     </footer>

--- a/app/(home)/components/footer/Footer.tsx
+++ b/app/(home)/components/footer/Footer.tsx
@@ -1,5 +1,6 @@
-﻿import Link from 'next/link';
+import Link from 'next/link';
 import { Heart, Mail } from 'lucide-react';
+import { PRIVACY_POLICY_PATH, TERMS_OF_SERVICE_PATH } from '@/lib/privacy-consent';
 
 export default function Footer() {
   return (
@@ -61,13 +62,13 @@ export default function Footer() {
           <p>&copy; 2025 Style Me. All rights reserved.</p>
           <div className='flex items-center justify-center gap-4 text-sm'>
             <Link
-              href='/privacy'
+              href={PRIVACY_POLICY_PATH}
               className='hover:text-rose-400 transition-colors underline-offset-2 hover:underline'
             >
               개인정보처리방침
             </Link>
             <Link
-              href='/terms'
+              href={TERMS_OF_SERVICE_PATH}
               className='hover:text-rose-400 transition-colors underline-offset-2 hover:underline'
             >
               이용약관

--- a/app/(home)/components/header/Header.tsx
+++ b/app/(home)/components/header/Header.tsx
@@ -1,4 +1,4 @@
-import SiteHeader from '@/components/common/site-header/site-header';
+﻿import SiteHeader from '@/components/common/site-header/site-header';
 
 export default function Header() {
   const navItems = [
@@ -6,6 +6,8 @@ export default function Header() {
     { label: '후기', href: '#reviews' },
     { label: 'FAQ', href: '#faq' },
     { label: '문의', href: '#contact' },
+    { label: '개인정보처리방침', href: '/privacy' },
+    { label: '이용약관', href: '/terms' },
   ];
 
   return <SiteHeader navItems={navItems} />;

--- a/app/(home)/components/header/Header.tsx
+++ b/app/(home)/components/header/Header.tsx
@@ -1,4 +1,5 @@
-﻿import SiteHeader from '@/components/common/site-header/site-header';
+import SiteHeader from '@/components/common/site-header/site-header';
+import { PRIVACY_POLICY_PATH, TERMS_OF_SERVICE_PATH } from '@/lib/privacy-consent';
 
 export default function Header() {
   const navItems = [
@@ -6,8 +7,8 @@ export default function Header() {
     { label: '후기', href: '#reviews' },
     { label: 'FAQ', href: '#faq' },
     { label: '문의', href: '#contact' },
-    { label: '개인정보처리방침', href: '/privacy' },
-    { label: '이용약관', href: '/terms' },
+    { label: '개인정보처리방침', href: PRIVACY_POLICY_PATH },
+    { label: '이용약관', href: TERMS_OF_SERVICE_PATH },
   ];
 
   return <SiteHeader navItems={navItems} />;

--- a/app/apply/components/application-form/ApplicationForm.tsx
+++ b/app/apply/components/application-form/ApplicationForm.tsx
@@ -1,20 +1,27 @@
-'use client';
+﻿'use client';
 
+import Link from 'next/link';
+import Image from 'next/image';
+import { Camera, CreditCard, Smartphone, Upload, X } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
-import { Camera, CreditCard, Smartphone, Upload, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import Image from 'next/image';
 import { Checkbox } from '@/components/ui/checkbox';
 import { FormField } from '@/components/ui/form-field';
 import { useApplicationFormState } from '@/app/apply/components/application-form/useApplicationFormState';
 import { useImagePreviewUpload } from '@/app/apply/components/application-form/useImagePreviewUpload';
 import { useApplicationSubmit } from '@/app/apply/components/application-form/useApplicationSubmit';
+import {
+  POLICY_LINKS,
+  POLICY_VERSIONS,
+  PRIVACY_OPERATION_NOTICE,
+  REQUIRED_AGREEMENT_GUIDE_TEXT,
+} from '@/app/apply/components/application-form/application-form.constants';
 
 export default function ApplicationForm() {
-  const { formData, isFormValid, updateField } = useApplicationFormState();
+  const { formData, isFormValid, formErrors, updateField } = useApplicationFormState();
   const {
     fileInputRef,
     previewUrls,
@@ -28,6 +35,8 @@ export default function ApplicationForm() {
     isFormValid,
   });
 
+  const shouldShowRequiredAgreementError = !formData.agreePrivacy || !formData.agreeService;
+
   return (
     <div className='lg:col-span-2'>
       <Card className='border-0 shadow-lg'>
@@ -35,14 +44,13 @@ export default function ApplicationForm() {
           <CardTitle className='text-2xl text-gray-800'>신청 정보 입력</CardTitle>
         </CardHeader>
         <CardContent className='space-y-6'>
-          {/* Personal Information */}
           <div className='grid md:grid-cols-2 gap-4'>
             <FormField.Root>
               <Label htmlFor='name'>이름 *</Label>
               <Input
                 id='name'
                 value={formData.name}
-                onChange={(e) => updateField('name', e.target.value)}
+                onChange={(event) => updateField('name', event.target.value)}
                 placeholder='홍길동'
                 className='mt-1'
               />
@@ -52,7 +60,7 @@ export default function ApplicationForm() {
               <Input
                 id='phone'
                 value={formData.phone}
-                onChange={(e) => updateField('phone', e.target.value)}
+                onChange={(event) => updateField('phone', event.target.value)}
                 placeholder='010-1234-5678'
                 className='mt-1'
               />
@@ -65,7 +73,7 @@ export default function ApplicationForm() {
               id='email'
               type='email'
               value={formData.email}
-              onChange={(e) => updateField('email', e.target.value)}
+              onChange={(event) => updateField('email', event.target.value)}
               placeholder='example@email.com'
               className='mt-1'
             />
@@ -91,33 +99,32 @@ export default function ApplicationForm() {
 
           <div className='grid md:grid-cols-2 gap-4'>
             <FormField.Root>
-              <Label htmlFor='height'>키 (cm) *</Label>
+              <Label htmlFor='height'>키(cm) *</Label>
               <Input
                 id='height'
                 value={formData.height}
-                onChange={(e) => updateField('height', e.target.value)}
+                onChange={(event) => updateField('height', event.target.value)}
                 placeholder='165'
                 className='mt-1'
               />
             </FormField.Root>
             <FormField.Root>
-              <Label htmlFor='weight'>몸무게 (kg) *</Label>
+              <Label htmlFor='weight'>몸무게(kg) *</Label>
               <Input
                 id='weight'
                 value={formData.weight}
-                onChange={(e) => updateField('weight', e.target.value)}
+                onChange={(event) => updateField('weight', event.target.value)}
                 placeholder='55'
                 className='mt-1'
               />
             </FormField.Root>
           </div>
 
-          {/* Photo Upload Section */}
           <FormField.Root className='space-y-4'>
             <FormField.Header>
-              <Label>체형 사진 업로드 (선택사항)</Label>
+              <Label>체형 사진 업로드 (선택)</Label>
               <FormField.Description>
-                더 정확한 진단을 위해 전신 사진을 업로드해주세요. (최대 3장)
+                더 정확한 진단을 위해 전신 사진을 업로드할 수 있습니다. (최대 3장)
               </FormField.Description>
             </FormField.Header>
 
@@ -131,7 +138,7 @@ export default function ApplicationForm() {
                 className='hidden'
               />
               <Camera className='h-12 w-12 text-gray-400 mx-auto mb-4' />
-              <p className='text-gray-600 mb-2'>사진을 드래그하거나 클릭하여 업로드</p>
+              <p className='text-gray-600 mb-2'>사진을 드래그하거나 클릭해 업로드하세요.</p>
               <Button
                 type='button'
                 variant='outline'
@@ -144,16 +151,15 @@ export default function ApplicationForm() {
               <p className='text-xs text-gray-500 mt-2'>JPG, PNG 파일만 가능 (최대 5MB)</p>
             </div>
 
-            {uploadError && <p className='text-sm text-red-600'>{uploadError}</p>}
+            {uploadError ? <p className='text-sm text-red-600'>{uploadError}</p> : null}
 
-            {/* Uploaded Images Preview */}
-            {previewUrls.length > 0 && (
+            {previewUrls.length > 0 ? (
               <div className='grid grid-cols-3 gap-4'>
                 {previewUrls.map((previewUrl, index) => (
-                  <div key={index} className='relative'>
+                  <div key={previewUrl} className='relative'>
                     <Image
                       src={previewUrl}
-                      alt={`업로드된 이미지 ${index + 1}`}
+                      alt={`업로드한 이미지 ${index + 1}`}
                       className='w-full h-32 object-cover rounded-lg'
                       width={128}
                       height={128}
@@ -170,42 +176,95 @@ export default function ApplicationForm() {
                   </div>
                 ))}
               </div>
-            )}
+            ) : null}
           </FormField.Root>
 
-          {/* Privacy Agreement */}
           <div className='space-y-4 p-4 bg-gray-50 rounded-lg'>
-            <h4 className='font-semibold text-gray-800'>개인정보 수집 및 이용 동의</h4>
+            <h4 className='font-semibold text-gray-800'>개인정보 및 약관 동의</h4>
             <div className='space-y-3'>
-              <FormField.CheckItem>
+              <FormField.CheckItem className='items-start gap-2'>
                 <Checkbox
                   id='agreePrivacy'
+                  className='shrink-0 mt-0.5'
                   checked={formData.agreePrivacy}
                   onCheckedChange={(checked) => updateField('agreePrivacy', checked === true)}
                 />
-                <Label htmlFor='agreePrivacy' className='text-sm leading-relaxed'>
+                <Label htmlFor='agreePrivacy' className='text-sm leading-relaxed min-w-0 whitespace-normal break-keep'>
                   개인정보 수집 및 이용에 동의합니다. (필수)
-                  <br />
-                  <span className='text-gray-500'>
-                    수집항목: 이름, 연락처, 이메일, 신체정보, 사진(선택) / 이용목적: 골격진단 서비스
-                    제공 / 보관기간: 서비스 완료 후 1년
+                  <span className='block text-gray-500 mt-1'>
+                    수집 항목: 이름, 연락처, 이메일, 성별, 키/몸무게
+                    <br />
+                    이용 목적: 골격 진단 서비스 제공 및 결과 안내
+                    <br />
+                    보관 기간: {PRIVACY_OPERATION_NOTICE.retention}
                   </span>
                 </Label>
               </FormField.CheckItem>
-              <FormField.CheckItem>
+
+              <FormField.CheckItem className='items-start gap-2'>
                 <Checkbox
                   id='agreeService'
+                  className='shrink-0 mt-0.5'
                   checked={formData.agreeService}
                   onCheckedChange={(checked) => updateField('agreeService', checked === true)}
                 />
-                <Label htmlFor='agreeService' className='text-sm'>
+                <Label htmlFor='agreeService' className='text-sm min-w-0 whitespace-normal break-keep'>
                   서비스 이용약관에 동의합니다. (필수)
                 </Label>
               </FormField.CheckItem>
+
+              <FormField.CheckItem className='items-start gap-2'>
+                <Checkbox
+                  id='agreePhotoProcessing'
+                  className='shrink-0 mt-0.5'
+                  checked={formData.agreePhotoProcessing}
+                  onCheckedChange={(checked) => updateField('agreePhotoProcessing', checked === true)}
+                />
+                <Label htmlFor='agreePhotoProcessing' className='text-sm min-w-0 whitespace-normal break-keep'>
+                  선택 업로드 사진 처리에 동의합니다. (선택)
+                </Label>
+              </FormField.CheckItem>
+
+              <FormField.CheckItem className='items-start gap-2'>
+                <Checkbox
+                  id='agreeMarketing'
+                  className='shrink-0 mt-0.5'
+                  checked={formData.agreeMarketing}
+                  onCheckedChange={(checked) => updateField('agreeMarketing', checked === true)}
+                />
+                <Label htmlFor='agreeMarketing' className='text-sm min-w-0 whitespace-normal break-keep'>
+                  이벤트/혜택 안내 수신에 동의합니다. (선택)
+                </Label>
+              </FormField.CheckItem>
             </div>
+
+            <div className='text-xs text-gray-600 leading-relaxed space-y-1 break-keep'>
+              <p>
+                필수 문서:
+                {' '}
+                <Link href={POLICY_LINKS.privacy} className='underline underline-offset-2'>
+                  개인정보처리방침
+                </Link>
+                {' '}
+                (v{POLICY_VERSIONS.privacy}),
+                {' '}
+                <Link href={POLICY_LINKS.terms} className='underline underline-offset-2'>
+                  이용약관
+                </Link>
+                {' '}
+                (v{POLICY_VERSIONS.terms})
+              </p>
+              <p>{PRIVACY_OPERATION_NOTICE.thirdParty}</p>
+              <p>권리행사(열람/정정/삭제) 요청: {PRIVACY_OPERATION_NOTICE.rights}</p>
+            </div>
+
+            {shouldShowRequiredAgreementError ? (
+              <p className='text-sm text-red-600'>
+                {formErrors.requiredAgreement ?? REQUIRED_AGREEMENT_GUIDE_TEXT}
+              </p>
+            ) : null}
           </div>
 
-          {/* Payment Method */}
           <div>
             <Label>결제 수단 선택 *</Label>
             <RadioGroup
@@ -231,7 +290,6 @@ export default function ApplicationForm() {
             </RadioGroup>
           </div>
 
-          {/* Submit Button */}
           <div className='pt-6'>
             <Button
               onClick={handleSubmit}
@@ -244,12 +302,12 @@ export default function ApplicationForm() {
                   신청 진행 중...
                 </div>
               ) : (
-                `무료로 진단 시작하기 🎉`
+                '무료로 진단 시작하기 🚀'
               )}
             </Button>
-            {submitError && <p className='text-sm text-red-600 text-center mt-2'>{submitError}</p>}
+            {submitError ? <p className='text-sm text-red-600 text-center mt-2'>{submitError}</p> : null}
             <p className='text-sm text-gray-500 text-center mt-2'>
-              런칭 기념 무료 이벤트! 신청 완료 후 즉시 골격진단을 시작할 수 있습니다.
+              이벤트 기간 무료 신청 완료 후 즉시 골격진단이 시작됩니다.
             </p>
           </div>
         </CardContent>

--- a/app/apply/components/application-form/application-form.constants.ts
+++ b/app/apply/components/application-form/application-form.constants.ts
@@ -1,5 +1,15 @@
 import { BodyDiagnosisFormData } from '@/types/body';
 import { IS_E2E_TEST_MODE } from '@/lib/e2e-mode';
+import {
+  CONSENT_NOTICE_VERSION,
+  DATA_RETENTION_POLICY,
+  PRIVACY_POLICY_PATH,
+  PRIVACY_POLICY_VERSION,
+  RIGHTS_REQUEST_CHANNEL,
+  TERMS_OF_SERVICE_PATH,
+  TERMS_OF_SERVICE_VERSION,
+  THIRD_PARTY_NOTICE,
+} from '@/lib/privacy-consent';
 
 export const MAX_UPLOAD_IMAGE_COUNT = 3;
 export const MAX_UPLOAD_IMAGE_SIZE_MB = 5;
@@ -7,6 +17,26 @@ export const MAX_UPLOAD_IMAGE_SIZE_BYTES = MAX_UPLOAD_IMAGE_SIZE_MB * 1024 * 102
 export const ALLOWED_IMAGE_MIME_TYPES = ['image/jpeg', 'image/png'] as const;
 
 export const SUBMIT_DELAY_MS = IS_E2E_TEST_MODE ? 0 : 2000;
+
+export const REQUIRED_AGREEMENT_GUIDE_TEXT =
+  '신청을 진행하려면 개인정보 수집·이용 및 서비스 이용약관 동의가 필요합니다.';
+
+export const POLICY_LINKS = {
+  privacy: PRIVACY_POLICY_PATH,
+  terms: TERMS_OF_SERVICE_PATH,
+} as const;
+
+export const POLICY_VERSIONS = {
+  privacy: PRIVACY_POLICY_VERSION,
+  terms: TERMS_OF_SERVICE_VERSION,
+  consentNotice: CONSENT_NOTICE_VERSION,
+} as const;
+
+export const PRIVACY_OPERATION_NOTICE = {
+  retention: DATA_RETENTION_POLICY,
+  rights: RIGHTS_REQUEST_CHANNEL,
+  thirdParty: THIRD_PARTY_NOTICE,
+} as const;
 
 export const INITIAL_APPLICATION_FORM_DATA: BodyDiagnosisFormData = {
   name: '',
@@ -17,5 +47,7 @@ export const INITIAL_APPLICATION_FORM_DATA: BodyDiagnosisFormData = {
   weight: '',
   agreePrivacy: false,
   agreeService: false,
+  agreePhotoProcessing: false,
+  agreeMarketing: false,
   paymentMethod: '',
 };

--- a/app/apply/components/application-form/application-form.validation.ts
+++ b/app/apply/components/application-form/application-form.validation.ts
@@ -18,7 +18,16 @@ const isPositiveNumberText = (value: string) => {
   return Number.isInteger(parsedValue) && parsedValue > 0;
 };
 
-export const isApplicationFormValid = (formData: BodyDiagnosisFormData) => {
+export type ApplicationFormValidation = {
+  isValid: boolean;
+  errors: {
+    requiredAgreement: string | null;
+  };
+};
+
+export const validateApplicationForm = (
+  formData: BodyDiagnosisFormData,
+): ApplicationFormValidation => {
   const hasAllRequiredTextValues = REQUIRED_TEXT_FIELDS.every((field) =>
     hasTextValue(formData[field]),
   );
@@ -26,5 +35,17 @@ export const isApplicationFormValid = (formData: BodyDiagnosisFormData) => {
   const hasValidHeight = isPositiveNumberText(formData.height);
   const hasValidWeight = isPositiveNumberText(formData.weight);
 
-  return hasAllRequiredTextValues && hasAllRequiredAgreements && hasValidHeight && hasValidWeight;
+  const requiredAgreement = hasAllRequiredAgreements
+    ? null
+    : '필수 동의 항목(개인정보 수집·이용, 서비스 이용약관)에 동의해 주세요.';
+
+  return {
+    isValid: hasAllRequiredTextValues && hasAllRequiredAgreements && hasValidHeight && hasValidWeight,
+    errors: {
+      requiredAgreement,
+    },
+  };
 };
+
+export const isApplicationFormValid = (formData: BodyDiagnosisFormData) =>
+  validateApplicationForm(formData).isValid;

--- a/app/apply/components/application-form/useApplicationFormState.ts
+++ b/app/apply/components/application-form/useApplicationFormState.ts
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import { BodyDiagnosisFormData } from '@/types/body';
 import { INITIAL_APPLICATION_FORM_DATA } from '@/app/apply/components/application-form/application-form.constants';
-import { isApplicationFormValid } from '@/app/apply/components/application-form/application-form.validation';
+import { validateApplicationForm } from '@/app/apply/components/application-form/application-form.validation';
 
 export function useApplicationFormState() {
   const [formData, setFormData] = useState<BodyDiagnosisFormData>(INITIAL_APPLICATION_FORM_DATA);
@@ -13,11 +13,12 @@ export function useApplicationFormState() {
     setFormData((prev) => ({ ...prev, [field]: value }));
   };
 
-  const isFormValid = useMemo(() => isApplicationFormValid(formData), [formData]);
+  const validationResult = useMemo(() => validateApplicationForm(formData), [formData]);
 
   return {
     formData,
-    isFormValid,
+    isFormValid: validationResult.isValid,
+    formErrors: validationResult.errors,
     updateField,
   };
 }

--- a/app/apply/components/application-form/useApplicationSubmit.ts
+++ b/app/apply/components/application-form/useApplicationSubmit.ts
@@ -14,6 +14,18 @@ type UseApplicationSubmitParams = {
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const isAlreadyAppliedError = (error: unknown) => {
+  if (error instanceof Error && error.message === 'application already exists for this phone') {
+    return true;
+  }
+
+  if (typeof error !== 'object' || error === null || !('code' in error)) {
+    return false;
+  }
+
+  return (error as { code?: string }).code === 'permission-denied';
+};
+
 export function useApplicationSubmit({ formData, isFormValid }: UseApplicationSubmitParams) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -49,6 +61,11 @@ export function useApplicationSubmit({ formData, isFormValid }: UseApplicationSu
         feature: 'apply',
         action: 'submit-application',
       });
+      if (isAlreadyAppliedError(error)) {
+        setSubmitError(USER_ERROR_MESSAGES.APPLICATION_ALREADY_EXISTS);
+        return;
+      }
+
       setSubmitError(USER_ERROR_MESSAGES.GENERIC_RETRY);
     } finally {
       setIsSubmitting(false);

--- a/app/apply/components/application-form/useApplicationSubmit.ts
+++ b/app/apply/components/application-form/useApplicationSubmit.ts
@@ -27,7 +27,7 @@ export function useApplicationSubmit({ formData, isFormValid }: UseApplicationSu
     const weight = Number.parseInt(formData.weight, 10);
 
     if (Number.isNaN(height) || Number.isNaN(weight) || height <= 0 || weight <= 0) {
-      setSubmitError('키와 몸무게는 0보다 큰 숫자로 입력해주세요.');
+      setSubmitError('키와 몸무게는 0보다 큰 숫자로 입력해 주세요.');
       return;
     }
 
@@ -61,4 +61,3 @@ export function useApplicationSubmit({ formData, isFormValid }: UseApplicationSu
     handleSubmit,
   };
 }
-

--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,71 @@
+import type { Metadata } from 'next';
+import PageBackground from '@/components/common/page-background/page-background';
+import PageContainer from '@/components/common/page-container/page-container';
+import {
+  CONSENT_NOTICE_VERSION,
+  DATA_RETENTION_POLICY,
+  PRIVACY_POLICY_VERSION,
+  RIGHTS_REQUEST_CHANNEL,
+  TERMS_OF_SERVICE_VERSION,
+  THIRD_PARTY_NOTICE,
+} from '@/lib/privacy-consent';
+
+export const metadata: Metadata = {
+  title: '개인정보처리방침',
+  description: 'Style Me 개인정보 처리 기준과 이용자 권리 안내',
+  alternates: {
+    canonical: '/privacy',
+  },
+};
+
+export default function PrivacyPage() {
+  return (
+    <PageBackground className='bg-gradient-to-br from-slate-50 via-white to-rose-50 py-10 px-4'>
+      <PageContainer className='max-w-3xl'>
+        <main className='bg-white rounded-2xl shadow-sm border border-slate-200 p-6 md:p-8 space-y-5'>
+          <h1 className='text-2xl font-bold text-slate-900'>개인정보처리방침</h1>
+          <p className='text-sm text-slate-600'>버전: v{PRIVACY_POLICY_VERSION}</p>
+
+          <section className='space-y-2'>
+            <h2 className='text-lg font-semibold text-slate-900'>1. 수집 항목</h2>
+            <p className='text-sm text-slate-700'>
+              이름, 연락처, 이메일, 성별, 키/몸무게, 선택 항목(사진 업로드 동의/마케팅 동의), 결제수단
+            </p>
+          </section>
+
+          <section className='space-y-2'>
+            <h2 className='text-lg font-semibold text-slate-900'>2. 이용 목적</h2>
+            <p className='text-sm text-slate-700'>
+              골격 진단 서비스 제공, 결과 안내, 서비스 품질 개선, 고객 문의 대응
+            </p>
+          </section>
+
+          <section className='space-y-2'>
+            <h2 className='text-lg font-semibold text-slate-900'>3. 보관 및 파기</h2>
+            <p className='text-sm text-slate-700'>{DATA_RETENTION_POLICY}</p>
+          </section>
+
+          <section className='space-y-2'>
+            <h2 className='text-lg font-semibold text-slate-900'>4. 처리위탁/제3자 관련 안내</h2>
+            <p className='text-sm text-slate-700'>{THIRD_PARTY_NOTICE}</p>
+          </section>
+
+          <section className='space-y-2'>
+            <h2 className='text-lg font-semibold text-slate-900'>5. 이용자 권리 행사</h2>
+            <p className='text-sm text-slate-700'>
+              열람/정정/삭제 요청은 다음 채널로 접수할 수 있습니다: {RIGHTS_REQUEST_CHANNEL}
+            </p>
+          </section>
+
+          <section className='space-y-2'>
+            <h2 className='text-lg font-semibold text-slate-900'>6. 동의 버전 관리</h2>
+            <p className='text-sm text-slate-700'>
+              개인정보처리방침 v{PRIVACY_POLICY_VERSION}, 이용약관 v{TERMS_OF_SERVICE_VERSION}, 고지문
+              v{CONSENT_NOTICE_VERSION} 기준으로 동의 이력을 저장합니다.
+            </p>
+          </section>
+        </main>
+      </PageContainer>
+    </PageBackground>
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -8,7 +8,7 @@ export default function robots(): MetadataRoute.Robots {
     rules: [
       {
         userAgent: '*',
-        allow: ['/', '/apply'],
+        allow: ['/', '/apply', '/privacy', '/terms'],
         disallow: ['/survey', '/result', '/complete'],
       },
     ],

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -18,5 +18,17 @@ export default function sitemap(): MetadataRoute.Sitemap {
       changeFrequency: 'weekly',
       priority: 0.8,
     },
+    {
+      url: `${siteUrl}/privacy`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.4,
+    },
+    {
+      url: `${siteUrl}/terms`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.4,
+    },
   ];
 }

--- a/app/survey/components/header/Header.tsx
+++ b/app/survey/components/header/Header.tsx
@@ -1,4 +1,4 @@
-import SiteHeader from '@/components/common/site-header/site-header';
+﻿import SiteHeader from '@/components/common/site-header/site-header';
 
 export default function Header() {
   const navItems = [
@@ -6,6 +6,8 @@ export default function Header() {
     { label: '서비스', href: '/public#service' },
     { label: '후기', href: '/public#reviews' },
     { label: 'FAQ', href: '/public#faq' },
+    { label: '개인정보처리방침', href: '/privacy' },
+    { label: '이용약관', href: '/terms' },
   ];
 
   return <SiteHeader brandHref='/public' navItems={navItems} />;

--- a/app/survey/components/header/Header.tsx
+++ b/app/survey/components/header/Header.tsx
@@ -1,4 +1,5 @@
-﻿import SiteHeader from '@/components/common/site-header/site-header';
+import SiteHeader from '@/components/common/site-header/site-header';
+import { PRIVACY_POLICY_PATH, TERMS_OF_SERVICE_PATH } from '@/lib/privacy-consent';
 
 export default function Header() {
   const navItems = [
@@ -6,8 +7,8 @@ export default function Header() {
     { label: '서비스', href: '/public#service' },
     { label: '후기', href: '/public#reviews' },
     { label: 'FAQ', href: '/public#faq' },
-    { label: '개인정보처리방침', href: '/privacy' },
-    { label: '이용약관', href: '/terms' },
+    { label: '개인정보처리방침', href: PRIVACY_POLICY_PATH },
+    { label: '이용약관', href: TERMS_OF_SERVICE_PATH },
   ];
 
   return <SiteHeader brandHref='/public' navItems={navItems} />;

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+import PageBackground from '@/components/common/page-background/page-background';
+import PageContainer from '@/components/common/page-container/page-container';
+import { TERMS_OF_SERVICE_VERSION } from '@/lib/privacy-consent';
+
+export const metadata: Metadata = {
+  title: '서비스 이용약관',
+  description: 'Style Me 서비스 이용약관 안내',
+  alternates: {
+    canonical: '/terms',
+  },
+};
+
+export default function TermsPage() {
+  return (
+    <PageBackground className='bg-gradient-to-br from-slate-50 via-white to-amber-50 py-10 px-4'>
+      <PageContainer className='max-w-3xl'>
+        <main className='bg-white rounded-2xl shadow-sm border border-slate-200 p-6 md:p-8 space-y-5'>
+          <h1 className='text-2xl font-bold text-slate-900'>서비스 이용약관</h1>
+          <p className='text-sm text-slate-600'>버전: v{TERMS_OF_SERVICE_VERSION}</p>
+
+          <section className='space-y-2'>
+            <h2 className='text-lg font-semibold text-slate-900'>1. 서비스 목적</h2>
+            <p className='text-sm text-slate-700'>
+              본 서비스는 이용자가 입력한 정보 기반으로 골격 진단 및 스타일링 가이드를 제공합니다.
+            </p>
+          </section>
+
+          <section className='space-y-2'>
+            <h2 className='text-lg font-semibold text-slate-900'>2. 이용자 의무</h2>
+            <p className='text-sm text-slate-700'>
+              이용자는 본인 정보를 정확히 입력해야 하며, 타인의 정보를 무단으로 입력해서는 안 됩니다.
+            </p>
+          </section>
+
+          <section className='space-y-2'>
+            <h2 className='text-lg font-semibold text-slate-900'>3. 이용 제한</h2>
+            <p className='text-sm text-slate-700'>
+              비정상적 요청, 시스템 악용, 부정 사용이 확인되는 경우 서비스 이용이 제한될 수 있습니다.
+            </p>
+          </section>
+
+          <section className='space-y-2'>
+            <h2 className='text-lg font-semibold text-slate-900'>4. 약관 변경</h2>
+            <p className='text-sm text-slate-700'>
+              약관이 변경되는 경우 적용일 전에 공지하며, 변경 버전이 신청 화면 및 정책 문서에 반영됩니다.
+            </p>
+          </section>
+        </main>
+      </PageContainer>
+    </PageBackground>
+  );
+}

--- a/components/auth-guard.tsx
+++ b/components/auth-guard.tsx
@@ -1,4 +1,4 @@
-﻿'use client';
+'use client';
 
 import type React from 'react';
 
@@ -17,6 +17,7 @@ import PageContainer from '@/components/common/page-container/page-container';
 import { setStorageJson, STORAGE_KEYS } from '@/lib/client-storage';
 import { captureAppError, USER_ERROR_MESSAGES } from '@/lib/error-policy';
 import { IS_E2E_TEST_MODE } from '@/lib/e2e-mode';
+import { PRIVACY_POLICY_PATH, TERMS_OF_SERVICE_PATH } from '@/lib/privacy-consent';
 
 const AUTH_SUCCESS_REDIRECT_DELAY_MS = IS_E2E_TEST_MODE ? 0 : 1500;
 
@@ -41,8 +42,8 @@ function AuthSuccessMessage() {
       <div className='inline-flex items-center justify-center w-16 h-16 bg-green-500 rounded-full mb-6'>
         <CheckCircle className='h-8 w-8 text-white' />
       </div>
-      <h3 className='text-xl font-bold text-green-600 mb-2'>?몄쬆 ?꾨즺!</h3>
-      <p className='text-gray-600'>?좎떆 ???섏씠吏濡??대룞?⑸땲??..</p>
+      <h3 className='text-xl font-bold text-green-600 mb-2'>인증 완료!</h3>
+      <p className='text-gray-600'>잠시 후 페이지로 이동합니다...</p>
     </div>
   );
 }
@@ -88,21 +89,21 @@ function AuthPhoneVerificationForm({
         {isPending ? (
           <div className='flex items-center'>
             <div className='animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2'></div>
-            ?몄쬆 以?..
+            인증 중...
           </div>
         ) : (
-          '?몄쬆?섍린'
+          '인증하기'
         )}
       </Button>
 
       <div className='text-center'>
-        <p className='text-sm text-gray-500 mb-4'>?꾩쭅 寃곗젣瑜??꾨즺?섏? ?딆쑝?⑤굹??</p>
+        <p className='text-sm text-gray-500 mb-4'>아직 결제를 완료하지 않으셨나요?</p>
         <Link href='/apply'>
           <Button
             variant='outline'
             className='border-2 border-pink-400 text-pink-600 hover:bg-pink-50 bg-transparent'
           >
-            寃곗젣?섎윭 媛湲?
+            결제하러 가기
           </Button>
         </Link>
       </div>
@@ -188,8 +189,8 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
             navItems={[
               { label: '홈', href: '/' },
               { label: '신청하기', href: '/apply' },
-              { label: '개인정보처리방침', href: '/privacy' },
-              { label: '이용약관', href: '/terms' },
+              { label: '개인정보처리방침', href: PRIVACY_POLICY_PATH },
+              { label: '이용약관', href: TERMS_OF_SERVICE_PATH },
             ]}
           />
         )}
@@ -200,7 +201,7 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
               <div className='inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-pink-500 to-purple-600 rounded-full mb-6 shadow-lg'>
                 <Shield className='h-8 w-8 text-white' />
               </div>
-              <h1 className='text-3xl font-bold text-gray-800 mb-4'>?묎렐 ?몄쬆</h1>
+              <h1 className='text-3xl font-bold text-gray-800 mb-4'>결제 인증</h1>
               <p className='text-gray-600'>
                 {requiredPage === 'complete' ? '결제 완료' : '골격진단'} 페이지는 결제를 완료한
                 고객만 이용할 수 있습니다.
@@ -244,4 +245,3 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
 
   return <>{children}</>;
 }
-

--- a/components/auth-guard.tsx
+++ b/components/auth-guard.tsx
@@ -1,4 +1,4 @@
-'use client';
+﻿'use client';
 
 import type React from 'react';
 
@@ -41,8 +41,8 @@ function AuthSuccessMessage() {
       <div className='inline-flex items-center justify-center w-16 h-16 bg-green-500 rounded-full mb-6'>
         <CheckCircle className='h-8 w-8 text-white' />
       </div>
-      <h3 className='text-xl font-bold text-green-600 mb-2'>인증 완료!</h3>
-      <p className='text-gray-600'>잠시 후 페이지로 이동합니다...</p>
+      <h3 className='text-xl font-bold text-green-600 mb-2'>?몄쬆 ?꾨즺!</h3>
+      <p className='text-gray-600'>?좎떆 ???섏씠吏濡??대룞?⑸땲??..</p>
     </div>
   );
 }
@@ -59,7 +59,7 @@ function AuthPhoneVerificationForm({
     <div className='space-y-6'>
       <div>
         <Label htmlFor='phone' className='text-gray-700 font-medium'>
-          결제 시 입력한 전화번호를 입력해주세요
+          寃곗젣 ???낅젰???꾪솕踰덊샇瑜??낅젰?댁＜?몄슂
         </Label>
         <Input
           id='phone'
@@ -88,31 +88,31 @@ function AuthPhoneVerificationForm({
         {isPending ? (
           <div className='flex items-center'>
             <div className='animate-spin rounded-full h-5 w-5 border-b-2 border-white mr-2'></div>
-            인증 중...
+            ?몄쬆 以?..
           </div>
         ) : (
-          '인증하기'
+          '?몄쬆?섍린'
         )}
       </Button>
 
       <div className='text-center'>
-        <p className='text-sm text-gray-500 mb-4'>아직 결제를 완료하지 않으셨나요?</p>
+        <p className='text-sm text-gray-500 mb-4'>?꾩쭅 寃곗젣瑜??꾨즺?섏? ?딆쑝?⑤굹??</p>
         <Link href='/apply'>
           <Button
             variant='outline'
             className='border-2 border-pink-400 text-pink-600 hover:bg-pink-50 bg-transparent'
           >
-            결제하러 가기
+            寃곗젣?섎윭 媛湲?
           </Button>
         </Link>
       </div>
 
       <div className='bg-blue-50 border border-blue-200 rounded-lg p-4'>
-        <h4 className='font-semibold text-blue-800 mb-2'>💡 도움말</h4>
+        <h4 className='font-semibold text-blue-800 mb-2'>꼭 확인하세요</h4>
         <ul className='text-sm text-blue-700 space-y-1'>
-          <li>• 결제 시 입력한 전화번호와 정확히 일치해야 합니다</li>
-          <li>• 인증은 24시간 동안 유효합니다</li>
-          <li>• 문제가 있으시면 고객센터로 문의해주세요</li>
+          <li>결제 시 입력한 전화번호와 정확히 일치해야 합니다.</li>
+          <li>인증은 24시간 동안 유효합니다.</li>
+          <li>문제가 있으면 고객센터로 문의해 주세요.</li>
         </ul>
       </div>
     </div>
@@ -134,7 +134,7 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
     const normalizedPhoneNumber = phoneNumber.replace(/[^0-9]/g, '');
 
     if (!normalizedPhoneNumber) {
-      setError('전화번호를 입력해주세요.');
+      setError('?꾪솕踰덊샇瑜??낅젰?댁＜?몄슂.');
       return;
     }
 
@@ -142,7 +142,7 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
       const doesPaymentInfoExist = await verifyPhoneNumber(normalizedPhoneNumber);
 
       if (!doesPaymentInfoExist) {
-        setError('결제 정보를 찾을 수 없습니다. 먼저 결제를 완료해주세요.');
+        setError('寃곗젣 ?뺣낫瑜?李얠쓣 ???놁뒿?덈떎. 癒쇱? 寃곗젣瑜??꾨즺?댁＜?몄슂.');
         return;
       }
 
@@ -188,6 +188,8 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
             navItems={[
               { label: '홈', href: '/' },
               { label: '신청하기', href: '/apply' },
+              { label: '개인정보처리방침', href: '/privacy' },
+              { label: '이용약관', href: '/terms' },
             ]}
           />
         )}
@@ -198,10 +200,10 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
               <div className='inline-flex items-center justify-center w-16 h-16 bg-gradient-to-r from-pink-500 to-purple-600 rounded-full mb-6 shadow-lg'>
                 <Shield className='h-8 w-8 text-white' />
               </div>
-              <h1 className='text-3xl font-bold text-gray-800 mb-4'>접근 인증</h1>
+              <h1 className='text-3xl font-bold text-gray-800 mb-4'>?묎렐 ?몄쬆</h1>
               <p className='text-gray-600'>
-                {requiredPage === 'complete' ? '결제 완료' : '골격진단'} 페이지는 결제를 완료한
-                고객만 이용할 수 있습니다.
+                {requiredPage === 'complete' ? '寃곗젣 ?꾨즺' : '怨④꺽吏꾨떒'} ?섏씠吏??寃곗젣瑜??꾨즺??
+                怨좉컼留??댁슜?????덉뒿?덈떎.
               </p>
             </div>
 
@@ -209,7 +211,7 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
               <CardHeader className='bg-gradient-to-r from-pink-500 to-purple-600 text-white rounded-t-lg'>
                 <CardTitle className='flex items-center text-xl'>
                   <Phone className='h-5 w-5 mr-2' />
-                  전화번호 인증
+                  ?꾪솕踰덊샇 ?몄쬆
                 </CardTitle>
               </CardHeader>
               <CardContent className='p-8'>
@@ -229,10 +231,9 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
             </Card>
 
             <div className='mt-8 text-center'>
-              <p className='text-sm text-gray-500 mb-2'>문의사항이 있으시면 연락주세요</p>
-              <div className='flex justify-center space-x-4 text-sm text-gray-600'>
-                <span>📧 contact@styleme.co.kr</span>
-                <span>📞 1588-0000</span>
+              <p className='text-sm text-gray-500 mb-2'>문의사항이 있으면 연락해 주세요.</p>
+              <div className='flex justify-center text-sm text-gray-600'>
+                <span>✉ yourmode0604@gmail.com</span>
               </div>
             </div>
           </PageContainer>
@@ -243,3 +244,4 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
 
   return <>{children}</>;
 }
+

--- a/components/auth-guard.tsx
+++ b/components/auth-guard.tsx
@@ -59,7 +59,7 @@ function AuthPhoneVerificationForm({
     <div className='space-y-6'>
       <div>
         <Label htmlFor='phone' className='text-gray-700 font-medium'>
-          寃곗젣 ???낅젰???꾪솕踰덊샇瑜??낅젰?댁＜?몄슂
+          결제 시 입력한 전화번호를 입력해주세요
         </Label>
         <Input
           id='phone'
@@ -134,7 +134,7 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
     const normalizedPhoneNumber = phoneNumber.replace(/[^0-9]/g, '');
 
     if (!normalizedPhoneNumber) {
-      setError('?꾪솕踰덊샇瑜??낅젰?댁＜?몄슂.');
+      setError('전화번호를 입력해주세요.');
       return;
     }
 
@@ -142,7 +142,7 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
       const doesPaymentInfoExist = await verifyPhoneNumber(normalizedPhoneNumber);
 
       if (!doesPaymentInfoExist) {
-        setError('寃곗젣 ?뺣낫瑜?李얠쓣 ???놁뒿?덈떎. 癒쇱? 寃곗젣瑜??꾨즺?댁＜?몄슂.');
+        setError('결제 정보를 찾을 수 없습니다. 먼저 결제를 완료해주세요.');
         return;
       }
 
@@ -202,8 +202,8 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
               </div>
               <h1 className='text-3xl font-bold text-gray-800 mb-4'>?묎렐 ?몄쬆</h1>
               <p className='text-gray-600'>
-                {requiredPage === 'complete' ? '寃곗젣 ?꾨즺' : '怨④꺽吏꾨떒'} ?섏씠吏??寃곗젣瑜??꾨즺??
-                怨좉컼留??댁슜?????덉뒿?덈떎.
+                {requiredPage === 'complete' ? '결제 완료' : '골격진단'} 페이지는 결제를 완료한
+                고객만 이용할 수 있습니다.
               </p>
             </div>
 
@@ -211,7 +211,7 @@ export default function AuthGuard({ children, requiredPage, showHeader = true }:
               <CardHeader className='bg-gradient-to-r from-pink-500 to-purple-600 text-white rounded-t-lg'>
                 <CardTitle className='flex items-center text-xl'>
                   <Phone className='h-5 w-5 mr-2' />
-                  ?꾪솕踰덊샇 ?몄쬆
+                  전화번호 인증
                 </CardTitle>
               </CardHeader>
               <CardContent className='p-8'>

--- a/docs/privacy-consent-ops.md
+++ b/docs/privacy-consent-ops.md
@@ -1,0 +1,62 @@
+# Apply 개인정보 운영 가이드
+
+## 목적
+
+- `/apply`에서 수집한 개인정보의 동의/보관/파기/권리행사 흐름을 운영 관점에서 일치시킨다.
+
+## 동의 로그 스키마
+
+- 문서: `apply/{phoneId}`
+- 필드:
+  - `requestId`: `"{phoneId}-{timestamp}"`
+  - `consentSnapshot`:
+    - `agreePrivacy`
+    - `agreeService`
+    - `agreePhotoProcessing`
+    - `agreeMarketing`
+    - `policyVersion`
+    - `termsVersion`
+    - `consentNoticeVersion`
+    - `agreedAtISO`
+    - `requestId`
+- 서브컬렉션: `apply/{phoneId}/consent_logs`
+  - 각 제출 시 `consentSnapshot` + `createdAt(serverTimestamp)` 기록
+
+## 보관/파기 운영 설계
+
+- 정책 문구: `서비스 종료 후 1년 보관 후 파기`
+- 운영 방식:
+  1. 기준일 계산: `createdAt` 또는 `updatedAt` 기준 1년 초과 데이터 탐색
+  2. 삭제 대상 검증: 파기 대상 레코드 수, 최근 요청 여부 확인
+  3. 배치 삭제: `apply/{phoneId}` 및 `consent_logs` 하위 문서 삭제
+  4. 실행 로그: 실행 시각, 삭제 건수, 실패 건수 별도 로그 저장
+- 권장 실행 주기: 주 1회 배치
+
+## 권리행사 처리 경로
+
+- 사용자 안내 문구: `하단 문의하기 폼 또는 카카오 채널`
+- 처리 절차:
+  1. 요청 접수
+  2. 본인 확인
+  3. 열람/정정/삭제 요청 처리
+  4. 처리 결과 회신 및 내부 이력 기록
+
+## QA 시나리오
+
+1. 필수 동의 미체크
+- 기대 결과: 제출 차단, 필수 동의 안내 문구 노출
+
+2. 선택 동의 거부
+- 기대 결과: 제출 가능, 저장 데이터에 선택 동의 `false` 반영
+
+3. 정책 링크 노출
+- 기대 결과: `/apply`에서 개인정보처리방침/이용약관 링크 클릭 가능
+
+4. 동의 버전 저장
+- 기대 결과: `consentSnapshot.policyVersion`, `termsVersion`, `consentNoticeVersion` 저장
+
+5. 동의 시각 저장
+- 기대 결과: `consentSnapshot.agreedAtISO` 및 `consent_logs.createdAt` 저장
+
+6. 요청 식별자 저장
+- 기대 결과: `requestId`가 `apply` 문서와 `consent_logs` 모두에 기록

--- a/firebase.ts
+++ b/firebase.ts
@@ -1,4 +1,4 @@
-﻿import { initializeApp } from 'firebase/app';
+import { initializeApp } from 'firebase/app';
 import {
   collection,
   doc,
@@ -40,33 +40,43 @@ if (typeof window !== 'undefined') {
 
 const normalizePhone = (raw: string) => raw.replace(/\D/g, '');
 
+const generateOpaqueRequestId = () => {
+  const randomUuid = globalThis.crypto?.randomUUID?.();
+  if (randomUuid) return randomUuid;
+
+  const fallbackRandomToken = Math.random().toString(36).slice(2, 12);
+  return `req_${Date.now()}_${fallbackRandomToken}`;
+};
+
 export const applyBodyDiagnosis = async (req: BodyDiagnosisFormData) => {
   if (IS_E2E_TEST_MODE) {
     return;
   }
 
   const phoneId = assertPhoneId(req.phone);
-  const requestId = `${phoneId}-${Date.now()}`;
+  const applyRef = doc(db, 'apply', phoneId);
+  const existingApply = await getDoc(applyRef);
+
+  if (existingApply.exists()) {
+    throw new Error('application already exists for this phone');
+  }
+
+  const requestId = generateOpaqueRequestId();
   const consentSnapshot = createConsentSnapshot(req, requestId);
   const batch = writeBatch(db);
-  const applyRef = doc(db, 'apply', phoneId);
   const consentLogRef = doc(collection(db, 'apply', phoneId, 'consent_logs'));
 
-  batch.set(
-    applyRef,
-    {
-      ...req,
-      phone: phoneId,
-      requestId,
-      consentSnapshot,
-      retentionPolicy: DATA_RETENTION_POLICY,
-      rightsRequestChannel: RIGHTS_REQUEST_CHANNEL,
-      thirdPartyNotice: THIRD_PARTY_NOTICE,
-      createdAt: serverTimestamp(),
-      updatedAt: serverTimestamp(),
-    },
-    { merge: true },
-  );
+  batch.set(applyRef, {
+    ...req,
+    phone: phoneId,
+    requestId,
+    consentSnapshot,
+    retentionPolicy: DATA_RETENTION_POLICY,
+    rightsRequestChannel: RIGHTS_REQUEST_CHANNEL,
+    thirdPartyNotice: THIRD_PARTY_NOTICE,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  });
 
   batch.set(consentLogRef, {
     ...consentSnapshot,

--- a/firebase.ts
+++ b/firebase.ts
@@ -1,12 +1,12 @@
 ﻿import { initializeApp } from 'firebase/app';
 import {
-  addDoc,
   collection,
   doc,
   getDoc,
   getFirestore,
   serverTimestamp,
   setDoc,
+  writeBatch,
 } from 'firebase/firestore';
 import { getAnalytics, isSupported } from 'firebase/analytics';
 import { BodyDiagnosisFormData } from '@/types/body';
@@ -45,12 +45,15 @@ export const applyBodyDiagnosis = async (req: BodyDiagnosisFormData) => {
     return;
   }
 
-  const phoneId = normalizePhone(req.phone);
+  const phoneId = assertPhoneId(req.phone);
   const requestId = `${phoneId}-${Date.now()}`;
   const consentSnapshot = createConsentSnapshot(req, requestId);
+  const batch = writeBatch(db);
+  const applyRef = doc(db, 'apply', phoneId);
+  const consentLogRef = doc(collection(db, 'apply', phoneId, 'consent_logs'));
 
-  await setDoc(
-    doc(db, 'apply', phoneId),
+  batch.set(
+    applyRef,
     {
       ...req,
       phone: phoneId,
@@ -65,10 +68,12 @@ export const applyBodyDiagnosis = async (req: BodyDiagnosisFormData) => {
     { merge: true },
   );
 
-  await addDoc(collection(db, 'apply', phoneId, 'consent_logs'), {
+  batch.set(consentLogRef, {
     ...consentSnapshot,
     createdAt: serverTimestamp(),
   });
+
+  await batch.commit();
 };
 
 const assertPhoneId = (raw: string) => {
@@ -121,7 +126,8 @@ export async function submitContactInquiry(req: ContactInquiryRequest): Promise<
     return 'test-contact-inquiry-id';
   }
 
-  const created = await addDoc(collection(db, 'contact_inquiries'), {
+  const created = doc(collection(db, 'contact_inquiries'));
+  await setDoc(created, {
     ...req,
     status: 'new',
     createdAt: serverTimestamp(),
@@ -141,7 +147,8 @@ export async function submitReview(req: ReviewRequest): Promise<string> {
     return 'test-review-id';
   }
 
-  const created = await addDoc(collection(db, 'reviews'), {
+  const created = doc(collection(db, 'reviews'));
+  await setDoc(created, {
     ...req,
     status: 'pending',
     createdAt: serverTimestamp(),

--- a/firebase.ts
+++ b/firebase.ts
@@ -1,13 +1,23 @@
-import { initializeApp } from 'firebase/app';
-import { addDoc, collection, doc, getDoc, getFirestore, setDoc, serverTimestamp } from 'firebase/firestore';
-import { BodyDiagnosisFormData } from '@/types/body';
+﻿import { initializeApp } from 'firebase/app';
+import {
+  addDoc,
+  collection,
+  doc,
+  getDoc,
+  getFirestore,
+  serverTimestamp,
+  setDoc,
+} from 'firebase/firestore';
 import { getAnalytics, isSupported } from 'firebase/analytics';
+import { BodyDiagnosisFormData } from '@/types/body';
 import { IS_E2E_TEST_MODE } from '@/lib/e2e-mode';
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
+import {
+  createConsentSnapshot,
+  DATA_RETENTION_POLICY,
+  RIGHTS_REQUEST_CHANNEL,
+  THIRD_PARTY_NOTICE,
+} from '@/lib/privacy-consent';
 
-// Your web app's Firebase configuration
-// For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
@@ -18,7 +28,6 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
-// Initialize Firebase
 const app = initializeApp(firebaseConfig);
 export const db = getFirestore(app);
 
@@ -37,12 +46,29 @@ export const applyBodyDiagnosis = async (req: BodyDiagnosisFormData) => {
   }
 
   const phoneId = normalizePhone(req.phone);
-  const newReq = {
-    ...req,
-    phone: phoneId,
-    createdAt: new Date().toLocaleString().toString(),
-  };
-  await setDoc(doc(db, 'apply', phoneId), newReq); // 문서 ID = phone
+  const requestId = `${phoneId}-${Date.now()}`;
+  const consentSnapshot = createConsentSnapshot(req, requestId);
+
+  await setDoc(
+    doc(db, 'apply', phoneId),
+    {
+      ...req,
+      phone: phoneId,
+      requestId,
+      consentSnapshot,
+      retentionPolicy: DATA_RETENTION_POLICY,
+      rightsRequestChannel: RIGHTS_REQUEST_CHANNEL,
+      thirdPartyNotice: THIRD_PARTY_NOTICE,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true },
+  );
+
+  await addDoc(collection(db, 'apply', phoneId, 'consent_logs'), {
+    ...consentSnapshot,
+    createdAt: serverTimestamp(),
+  });
 };
 
 const assertPhoneId = (raw: string) => {
@@ -52,7 +78,6 @@ const assertPhoneId = (raw: string) => {
   return id;
 };
 
-// 설문 답변 저장
 export async function saveSurveyAnswers(phone: string, answers: string[]): Promise<string> {
   if (IS_E2E_TEST_MODE) {
     return normalizePhone(phone);
@@ -68,7 +93,7 @@ export async function saveSurveyAnswers(phone: string, answers: string[]): Promi
       completedAt: serverTimestamp(),
     },
     { merge: true },
-  ); // 필요시 덮어쓰기 허용
+  );
   return ref.id;
 }
 

--- a/firebase.ts
+++ b/firebase.ts
@@ -40,11 +40,19 @@ if (typeof window !== 'undefined') {
 
 const normalizePhone = (raw: string) => raw.replace(/\D/g, '');
 
+const BASE36_FRACTION_START_INDEX = 2;
+const FALLBACK_REQUEST_TOKEN_LENGTH = 10;
+
 const generateOpaqueRequestId = () => {
   const randomUuid = globalThis.crypto?.randomUUID?.();
   if (randomUuid) return randomUuid;
 
-  const fallbackRandomToken = Math.random().toString(36).slice(2, 12);
+  const fallbackRandomToken = Math.random()
+    .toString(36)
+    .slice(
+      BASE36_FRACTION_START_INDEX,
+      BASE36_FRACTION_START_INDEX + FALLBACK_REQUEST_TOKEN_LENGTH,
+    );
   return `req_${Date.now()}_${fallbackRandomToken}`;
 };
 
@@ -55,16 +63,16 @@ export const applyBodyDiagnosis = async (req: BodyDiagnosisFormData) => {
 
   const phoneId = assertPhoneId(req.phone);
   const applyRef = doc(db, 'apply', phoneId);
-  const existingApply = await getDoc(applyRef);
-
-  if (existingApply.exists()) {
-    throw new Error('application already exists for this phone');
-  }
-
   const requestId = generateOpaqueRequestId();
   const consentSnapshot = createConsentSnapshot(req, requestId);
-  const batch = writeBatch(db);
   const consentLogRef = doc(collection(db, 'apply', phoneId, 'consent_logs'));
+  const applyIndexRef = doc(db, 'apply_index', phoneId);
+  const batch = writeBatch(db);
+  const existingApplyIndex = await getDoc(applyIndexRef);
+
+  if (existingApplyIndex.exists()) {
+    throw new Error('application already exists for this phone');
+  }
 
   batch.set(applyRef, {
     ...req,
@@ -80,6 +88,11 @@ export const applyBodyDiagnosis = async (req: BodyDiagnosisFormData) => {
 
   batch.set(consentLogRef, {
     ...consentSnapshot,
+    createdAt: serverTimestamp(),
+  });
+
+  batch.set(applyIndexRef, {
+    requestId,
     createdAt: serverTimestamp(),
   });
 
@@ -118,7 +131,8 @@ export async function valueExists(collectionName: string, phone: string): Promis
   }
 
   const phoneId = assertPhoneId(phone);
-  const snap = await getDoc(doc(db, collectionName, phoneId));
+  const targetCollection = collectionName === 'apply' ? 'apply_index' : collectionName;
+  const snap = await getDoc(doc(db, targetCollection, phoneId));
   return snap.exists();
 }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -83,11 +83,11 @@ service cloud.firestore {
         && request.resource.data.requestId is string
         && request.resource.data.createdAt is timestamp
         && request.resource.data.requestId ==
-          get(/databases/$(database)/documents/apply/$(phoneId)).data.requestId;
+          getAfter(/databases/$(database)/documents/apply/$(phoneId)).data.requestId;
     }
 
     match /apply/{phoneId} {
-      allow get: if isValidPhoneId(phoneId);
+      allow get: if false;
       allow list: if false;
       allow create: if isValidPhoneId(phoneId)
         && !exists(/databases/$(database)/documents/apply/$(phoneId))
@@ -97,10 +97,24 @@ service cloud.firestore {
 
       match /consent_logs/{logId} {
         allow create: if isValidPhoneId(phoneId)
-          && exists(/databases/$(database)/documents/apply/$(phoneId))
+          && existsAfter(/databases/$(database)/documents/apply/$(phoneId))
           && hasConsentLogShape(phoneId);
         allow read, update, delete: if false;
       }
+    }
+
+    match /apply_index/{phoneId} {
+      allow get: if isValidPhoneId(phoneId);
+      allow list: if false;
+      allow create: if isValidPhoneId(phoneId)
+        && !exists(/databases/$(database)/documents/apply_index/$(phoneId))
+        && request.resource.data.keys().hasOnly(['requestId', 'createdAt'])
+        && request.resource.data.requestId is string
+        && request.resource.data.createdAt is timestamp
+        && existsAfter(/databases/$(database)/documents/apply/$(phoneId))
+        && getAfter(/databases/$(database)/documents/apply/$(phoneId)).data.requestId ==
+          request.resource.data.requestId;
+      allow update, delete: if false;
     }
 
     match /surveys/{phoneId} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,19 +1,157 @@
-rules_version='2'
+rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
+    function isValidPhoneId(phoneId) {
+      return phoneId.matches('^[0-9]{10,11}$');
+    }
+
+    function hasApplyPayloadShape(phoneId) {
+      return request.resource.data.keys().hasOnly([
+          'name',
+          'phone',
+          'email',
+          'gender',
+          'height',
+          'weight',
+          'agreePrivacy',
+          'agreeService',
+          'agreePhotoProcessing',
+          'agreeMarketing',
+          'paymentMethod',
+          'requestId',
+          'consentSnapshot',
+          'retentionPolicy',
+          'rightsRequestChannel',
+          'thirdPartyNotice',
+          'createdAt',
+          'updatedAt',
+        ])
+        && request.resource.data.phone == phoneId
+        && request.resource.data.name is string
+        && request.resource.data.email is string
+        && request.resource.data.gender is string
+        && request.resource.data.height is string
+        && request.resource.data.weight is string
+        && request.resource.data.paymentMethod is string
+        && request.resource.data.agreePrivacy == true
+        && request.resource.data.agreeService == true
+        && request.resource.data.agreePhotoProcessing is bool
+        && request.resource.data.agreeMarketing is bool
+        && request.resource.data.requestId is string
+        && request.resource.data.retentionPolicy is string
+        && request.resource.data.rightsRequestChannel is string
+        && request.resource.data.thirdPartyNotice is string
+        && request.resource.data.createdAt is timestamp
+        && request.resource.data.updatedAt is timestamp;
+    }
+
+    function hasConsentSnapshotShape() {
+      return request.resource.data.consentSnapshot.agreePrivacy == true
+        && request.resource.data.consentSnapshot.agreeService == true
+        && request.resource.data.consentSnapshot.agreePhotoProcessing is bool
+        && request.resource.data.consentSnapshot.agreeMarketing is bool
+        && request.resource.data.consentSnapshot.policyVersion is string
+        && request.resource.data.consentSnapshot.termsVersion is string
+        && request.resource.data.consentSnapshot.consentNoticeVersion is string
+        && request.resource.data.consentSnapshot.agreedAtISO is string
+        && request.resource.data.consentSnapshot.requestId is string
+        && request.resource.data.consentSnapshot.requestId == request.resource.data.requestId;
+    }
+
+    function hasConsentLogShape(phoneId) {
+      return request.resource.data.keys().hasOnly([
+          'agreePrivacy',
+          'agreeService',
+          'agreePhotoProcessing',
+          'agreeMarketing',
+          'policyVersion',
+          'termsVersion',
+          'consentNoticeVersion',
+          'agreedAtISO',
+          'requestId',
+          'createdAt',
+        ])
+        && request.resource.data.agreePrivacy == true
+        && request.resource.data.agreeService == true
+        && request.resource.data.agreePhotoProcessing is bool
+        && request.resource.data.agreeMarketing is bool
+        && request.resource.data.policyVersion is string
+        && request.resource.data.termsVersion is string
+        && request.resource.data.consentNoticeVersion is string
+        && request.resource.data.agreedAtISO is string
+        && request.resource.data.requestId is string
+        && request.resource.data.createdAt is timestamp
+        && request.resource.data.requestId ==
+          get(/databases/$(database)/documents/apply/$(phoneId)).data.requestId;
+    }
+
+    match /apply/{phoneId} {
+      allow get: if isValidPhoneId(phoneId);
+      allow list: if false;
+      allow create: if isValidPhoneId(phoneId)
+        && !exists(/databases/$(database)/documents/apply/$(phoneId))
+        && hasApplyPayloadShape(phoneId)
+        && hasConsentSnapshotShape();
+      allow update, delete: if false;
+
+      match /consent_logs/{logId} {
+        allow create: if isValidPhoneId(phoneId)
+          && exists(/databases/$(database)/documents/apply/$(phoneId))
+          && hasConsentLogShape(phoneId);
+        allow read, update, delete: if false;
+      }
+    }
+
+    match /surveys/{phoneId} {
+      allow create, update: if isValidPhoneId(phoneId)
+        && request.resource.data.keys().hasOnly(['phone', 'answers', 'completedAt'])
+        && request.resource.data.phone == phoneId
+        && request.resource.data.answers is list
+        && request.resource.data.completedAt is timestamp;
+      allow read, delete: if false;
+    }
+
+    match /contact_inquiries/{inquiryId} {
+      allow create: if request.resource.data.keys().hasOnly([
+          'name',
+          'email',
+          'topic',
+          'message',
+          'source',
+          'status',
+          'createdAt',
+        ])
+        && request.resource.data.name is string
+        && request.resource.data.email is string
+        && request.resource.data.topic is string
+        && request.resource.data.message is string
+        && request.resource.data.source in ['floating-button', 'footer']
+        && request.resource.data.status == 'new'
+        && request.resource.data.createdAt is timestamp;
+      allow read, update, delete: if false;
+    }
+
+    match /reviews/{reviewId} {
+      allow create: if request.resource.data.keys().hasOnly([
+          'rating',
+          'comment',
+          'source',
+          'status',
+          'createdAt',
+        ])
+        && request.resource.data.rating is int
+        && request.resource.data.rating >= 1
+        && request.resource.data.rating <= 5
+        && request.resource.data.comment is string
+        && request.resource.data.source in ['result-page', 'pdf-download']
+        && request.resource.data.status == 'pending'
+        && request.resource.data.createdAt is timestamp;
+      allow read, update, delete: if false;
+    }
+
     match /{document=**} {
-      // This rule allows anyone with your database reference to view, edit,
-      // and delete all data in your database. It is useful for getting
-      // started, but it is configured to expire after 30 days because it
-      // leaves your app open to attackers. At that time, all client
-      // requests to your database will be denied.
-      //
-      // Make sure to write security rules for your app before that time, or
-      // else all client requests to your database will be denied until you
-      // update your rules.
-      allow read, write: if request.time < timestamp.date(2026, 12, 30);
-      allow create: if true;
+      allow read, write: if false;
     }
   }
 }

--- a/lib/error-policy.ts
+++ b/lib/error-policy.ts
@@ -3,9 +3,14 @@ import * as Sentry from '@sentry/nextjs';
 const ERROR_POLICY_VERSION = 'v1';
 
 export const USER_ERROR_MESSAGES = {
-  GENERIC_RETRY: '오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
-  RESULT_REQUEST_FAILED: '결과 요청에 실패했습니다. 잠시 후 다시 시도해주세요.',
-  PDF_GENERATION_FAILED: 'PDF 생성에 실패했습니다. 잠시 후 다시 시도해주세요.',
+  GENERIC_RETRY:
+    '오류가 발생했습니다. 잠시 후 다시 시도해주세요.',
+  APPLICATION_ALREADY_EXISTS:
+    '이미 해당 전화번호로 유효한 신청이 있습니다. 이름과 전화번호를 확인한 뒤 고객센터로 문의해주세요.',
+  RESULT_REQUEST_FAILED:
+    '결과 요청에 실패했습니다. 잠시 후 다시 시도해주세요.',
+  PDF_GENERATION_FAILED:
+    'PDF 생성에 실패했습니다. 잠시 후 다시 시도해주세요.',
 } as const;
 
 type ErrorLayer = 'api' | 'ui' | 'storage' | 'firebase';

--- a/lib/privacy-consent.ts
+++ b/lib/privacy-consent.ts
@@ -8,7 +8,7 @@ export const TERMS_OF_SERVICE_VERSION = '2026-03-04';
 export const CONSENT_NOTICE_VERSION = '2026-03-04';
 
 export const DATA_RETENTION_POLICY = '서비스 종료 후 1년 보관 후 파기';
-export const RIGHTS_REQUEST_CHANNEL = '하단 문의하기 폼 또는 카카오 채널';
+export const RIGHTS_REQUEST_CHANNEL = '하단 문의하기';
 export const THIRD_PARTY_NOTICE =
   '결제/메시지/이메일 발송 과정에서 처리위탁이 발생할 수 있으며, 상세 내용은 개인정보처리방침에서 확인할 수 있습니다.';
 

--- a/lib/privacy-consent.ts
+++ b/lib/privacy-consent.ts
@@ -1,0 +1,42 @@
+import { BodyDiagnosisFormData } from '@/types/body';
+
+export const PRIVACY_POLICY_PATH = '/privacy';
+export const TERMS_OF_SERVICE_PATH = '/terms';
+
+export const PRIVACY_POLICY_VERSION = '2026-03-04';
+export const TERMS_OF_SERVICE_VERSION = '2026-03-04';
+export const CONSENT_NOTICE_VERSION = '2026-03-04';
+
+export const DATA_RETENTION_POLICY = '서비스 종료 후 1년 보관 후 파기';
+export const RIGHTS_REQUEST_CHANNEL = '하단 문의하기 폼 또는 카카오 채널';
+export const THIRD_PARTY_NOTICE =
+  '결제/메시지/이메일 발송 과정에서 처리위탁이 발생할 수 있으며, 상세 내용은 개인정보처리방침에서 확인할 수 있습니다.';
+
+export type ConsentSnapshot = {
+  agreePrivacy: boolean;
+  agreeService: boolean;
+  agreePhotoProcessing: boolean;
+  agreeMarketing: boolean;
+  policyVersion: string;
+  termsVersion: string;
+  consentNoticeVersion: string;
+  agreedAtISO: string;
+  requestId: string;
+};
+
+export function createConsentSnapshot(
+  formData: BodyDiagnosisFormData,
+  requestId: string,
+): ConsentSnapshot {
+  return {
+    agreePrivacy: formData.agreePrivacy,
+    agreeService: formData.agreeService,
+    agreePhotoProcessing: formData.agreePhotoProcessing,
+    agreeMarketing: formData.agreeMarketing,
+    policyVersion: PRIVACY_POLICY_VERSION,
+    termsVersion: TERMS_OF_SERVICE_VERSION,
+    consentNoticeVersion: CONSENT_NOTICE_VERSION,
+    agreedAtISO: new Date().toISOString(),
+    requestId,
+  };
+}

--- a/types/body.ts
+++ b/types/body.ts
@@ -7,5 +7,7 @@ export interface BodyDiagnosisFormData {
   weight: string
   agreePrivacy: boolean
   agreeService: boolean
+  agreePhotoProcessing: boolean
+  agreeMarketing: boolean
   paymentMethod: string
 }


### PR DESCRIPTION
 ## Summary

  /apply 개인정보 처리 흐름을 운영 가능한 수준으로 정비했습니다.
  필수/선택 동의 구조를 분리하고, 정책 고지 링크/버전 관리/동의 이력 저장을 도입했으며, 개인정보처리방
  침/이용약관 페이지 및 운영 가이드를 추가했습니다.

  ## Related Issues

  - Closes #47

  ## Changes

  - /apply 폼 동의 UI 개편
      - 필수 동의: 개인정보 수집·이용, 서비스 이용약관
      - 선택 동의: 사진 처리, 마케팅 수신
      - 필수 미동의 시 제출 차단 + 사유 문구 노출
      - 정책 링크(개인정보처리방침/이용약관) 및 버전 표시
  - 동의 스키마/버전 상수 추가
      - lib/privacy-consent.ts
      - policy/terms/consentNotice 버전 상수, 동의 스냅샷 생성기
  - 타입/검증 로직 확장
      - BodyDiagnosisFormData에 선택 동의 필드 추가
      - validateApplicationForm로 필수 동의 에러 반환
  - Firestore 저장 강화
      - apply/{phoneId}에 requestId, consentSnapshot, 운영 고지 관련 필드 저장
      - apply/{phoneId}/consent_logs 서브컬렉션에 동의 로그 추가 저장
  - 정책 페이지 신설
      - /privacy, /terms
  - SEO/색인 정리
      - robots: 정책 페이지 허용
      - sitemap: /privacy, /terms 포함
  - 운영 문서 추가
      - docs/privacy-consent-ops.md (보관/파기/권리행사/QA 시나리오)

  ## How To Test

  1. pnpm build 실행
  2. pnpm start 후 /apply 진입
  3. 필수 동의 미체크 상태 확인
      - 제출 버튼 비활성 또는 제출 차단/에러 문구 노출 확인
  4. 선택 동의(사진 처리, 마케팅) 미체크 상태에서도 제출 가능 여부 확인
  5. /privacy, /terms 링크 클릭 동작 확인
  6. Firestore 확인
      - apply/{phoneId} 문서에 requestId, consentSnapshot, 버전/동의시각 저장 확인
      - apply/{phoneId}/consent_logs 생성 확인
  7. robots.txt, sitemap.xml 확인
      - 정책 페이지 포함 여부 확인

  ## Checklist

  - [x] Title follows the convention (e.g., feat: add global audio seek guard)
  - [x] Build passes locally (pnpm build)
  - [x] No breaking changes, or they are documented below
  - [ ] Tests added/updated where appropriate
  - [x] CodeRabbit comments reviewed and handled (accepted/deferred/ignored with reason)
  - [x] Docs/comments updated where helpful

  ## Breaking Changes (if any)

  - BodyDiagnosisFormData 스키마 확장:
      - agreePhotoProcessing: boolean
      - agreeMarketing: boolean
  - Firestore apply 문서 구조 확장:
      - requestId, consentSnapshot, retentionPolicy, rightsRequestChannel, thirdPartyNotice
  - 신규 서브컬렉션:
      - apply/{phoneId}/consent_logs

  ## Notes For Reviewers

  - 법률 자문 범위(문구 적법성)는 별도 트랙입니다. 본 PR은 기술/운영 정합성 강화에 초점이 있습니다.
  - firebase.ts 저장 구조 변경으로, 기존 데이터 조회 코드가 있다면 신규 필드와의 호환성 확인이 필요합
    니다.
  - 정책 버전은 lib/privacy-consent.ts에서 중앙 관리합니다.

  ## Screenshots / Recordings (if UI changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 개인정보·약관 페이지 추가 및 약관/개인정보 링크·버전 노출
  * 신청 양식에 사진 처리 동의·마케팅 동의 항목 추가, 사진 업로드 UI/문구 개선
  * 제출 전 동의 검증 강화 및 상세 오류 안내(필수 동의 메시지) 추가

* **문서**
  * 개인정보 운영 가이드(동의 로그, 보관·파기, 권리행사 절차) 추가

* **기타**
  * 동의 스냅샷 저장·추적과 원자적 제출 처리 도입, 보안 규칙 강화, 사용자 오류 메시지 확장
<!-- end of auto-generated comment: release notes by coderabbit.ai -->